### PR TITLE
React native 0.47 fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgePackage.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgePackage.java
@@ -22,9 +22,4 @@ public class WebViewBridgePackage implements ReactPackage {
                 new WebViewBridgeManager()
         );
     }
-
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Arrays.asList();
-    }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "invariant": "2.2.0",
     "keymirror": "0.1.1",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "create-react-class": "^15.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "main": "webview-bridge",
   "dependencies": {
     "invariant": "2.2.0",
-    "keymirror": "0.1.1"
+    "keymirror": "0.1.1",
+    "prop-types": "^15.5.10"
   }
 }

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -18,6 +18,8 @@ var ReactNative = require('react-native');
 var invariant = require('invariant');
 var keyMirror = require('keymirror');
 var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 
 var {
   ReactNativeViewAttributes,
@@ -33,7 +35,6 @@ var {
     WebViewBridgeManager
   }
 } = ReactNative;
-var PropTypes = require('prop-types');
 
 var RCT_WEBVIEWBRIDGE_REF = 'webviewbridge';
 
@@ -48,7 +49,7 @@ var RCTWebViewBridge = requireNativeComponent('RCTWebViewBridge', WebViewBridge)
 /**
  * Renders a native WebView.
  */
-var WebViewBridge = React.createClass({
+var WebViewBridge = createReactClass({
 
   propTypes: {
     ...RCTWebViewBridge.propTypes,

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -33,7 +33,7 @@ var {
     WebViewBridgeManager
   }
 } = ReactNative;
-var { PropTypes } = React;
+var PropTypes = require('prop-types');
 
 var RCT_WEBVIEWBRIDGE_REF = 'webviewbridge';
 

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -33,7 +33,7 @@ var {
     WebViewBridgeManager
   }
 } = ReactNative;
-var { PropTypes } = React;
+var PropTypes = require('prop-types');
 
 var BGWASH = 'rgba(255,255,255,0.8)';
 var RCT_WEBVIEWBRIDGE_REF = 'webviewbridge';

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -19,6 +19,8 @@ var ReactNative = require('react-native');
 var invariant = require('invariant');
 var keyMirror = require('keymirror');
 var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 
 var {
   ActivityIndicator,
@@ -33,7 +35,6 @@ var {
     WebViewBridgeManager
   }
 } = ReactNative;
-var PropTypes = require('prop-types');
 
 var BGWASH = 'rgba(255,255,255,0.8)';
 var RCT_WEBVIEWBRIDGE_REF = 'webviewbridge';
@@ -90,7 +91,7 @@ var defaultRenderError = (errorDomain, errorCode, errorDesc) => (
 /**
  * Renders a native WebView.
  */
-var WebViewBridge = React.createClass({
+var WebViewBridge = createReactClass({
   statics: {
     JSNavigationScheme: JSNavigationScheme,
     NavigationType: NavigationType,


### PR DESCRIPTION
Changes:
- removed deprecated java method createJSModules;
- added prop-types and create-react-class modules, because they were removed from latest react.